### PR TITLE
Allow LongCodeValue, ContainerContentItem not continuous

### DIFF
--- a/src/highdicom/sr/utils.py
+++ b/src/highdicom/sr/utils.py
@@ -90,10 +90,14 @@ def find_content_items(
         matched_content_items = []
         for i, content_item in enumerate(node.ContentSequence):
             name_code = content_item.ConceptNameCodeSequence[0]
+            try:
+                coding_value = name_code.CodeValue
+            except AttributeError:
+                coding_value = name_code.LongCodeValue
             item = ContentItem(
                 value_type=content_item.ValueType,
                 name=CodedConcept(
-                    value=name_code.CodeValue,
+                    value=coding_value,
                     scheme_designator=name_code.CodingSchemeDesignator,
                     meaning=name_code.CodeMeaning
                 ),

--- a/src/highdicom/sr/value_types.py
+++ b/src/highdicom/sr/value_types.py
@@ -1267,7 +1267,7 @@ class ContainerContentItem(ContentItem):
     def __init__(
         self,
         name: Union[Code, CodedConcept],
-        is_content_continuous: bool = True,
+        is_content_continuous: bool = False,
         template_id: Optional[str] = None,
         relationship_type: Union[str, RelationshipTypeValues, None] = None
     ) -> None:


### PR DESCRIPTION
Optionally use LongCodeValue when normal CodeValue fails Make is_content_continuous False be default to help rendering in SR viewers & HTML/XML output conversions